### PR TITLE
PR02-30092025: atualiza a lógica dos links do projeto e melhora a experiência do usuário nas seções de contato e projetos

### DIFF
--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -33,10 +33,18 @@ export function ContactSection() {
     e.preventDefault();
     setIsSubmitting(true);
 
-    // Simular envio do formulário
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    // Monta mensagem para WhatsApp
+    const whatsappNumber = contact.phone.replace(/[^0-9]/g, "");
+    const message =
+      `Olá, meu nome é ${formData.name}.%0A` +
+      `Assunto: ${formData.subject}%0A` +
+      `Email: ${formData.email}%0A` +
+      `Mensagem: ${formData.message}`;
 
-    toast.success("Mensagem enviada com sucesso! Entrarei em contato em breve.");
+    // Redireciona para WhatsApp
+    window.open(`https://wa.me/${whatsappNumber}?text=${message}`, "_blank");
+
+    toast.success("Redirecionando para o WhatsApp...");
     setFormData({ name: "", email: "", subject: "", message: "" });
     setIsSubmitting(false);
   };

--- a/src/components/sections/ProjectsSection.tsx
+++ b/src/components/sections/ProjectsSection.tsx
@@ -98,33 +98,28 @@ export function ProjectsSection() {
                   </div>
 
                   <div className={`${styles.buttonsContainer} ${styles.noPrint}`}>
-                    <a
-                      href={project.links?.demo}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={`${styles.button} ${styles.buttonPrimary}`}
-                    >
-                      <ExternalLink className={styles.buttonIcon} />
-                      Demo
-                    </a>
-                    <a
-                      href={project.links?.github}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={`${styles.button} ${styles.buttonOutline}`}
-                    >
-                      <Github className={styles.buttonIcon} />
-                      Código
-                    </a>
-                  </div>
-
-                  {/* PDF-only links section */}
-                  <div className={`${styles.printLinksSection} ${styles.printOnly}`}>
-                    <p>
-                      <strong>Links do projeto:</strong>
-                    </p>
-                    <p>• Demonstração: {project.links?.demo}</p>
-                    <p>• Código fonte: {project.links?.github}</p>
+                    {project.links?.demo && project.links.demo.trim() !== "" && (
+                      <a
+                        href={project.links.demo}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={`${styles.button} ${styles.buttonPrimary}`}
+                      >
+                        <ExternalLink className={styles.buttonIcon} />
+                        Demo
+                      </a>
+                    )}
+                    {project.links?.repo && project.links.repo.trim() !== "" && (
+                      <a
+                        href={project.links.repo}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={`${styles.button} ${styles.buttonOutline}`}
+                      >
+                        <Github className={styles.buttonIcon} />
+                        Código
+                      </a>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/pages/PrintPage.tsx
+++ b/src/pages/PrintPage.tsx
@@ -21,7 +21,7 @@ type Project = {
   description: string;
   links: {
     demo?: string;
-    github?: string;
+    repo?: string;
   };
 };
 
@@ -133,15 +133,19 @@ export function PrintPage({ onPrintFinish }: PrintPageProps) {
         <div className={styles.projectsSection}>
           <h3>Projetos</h3>
           {projects.map((project: Project, index: number) => (
-            <div key={index}>
+            <div key={index} className={styles.projectContainer}>
               <h4 className={styles.projectTitle}>{project.title}</h4>
               <p className={styles.projectDescription}>{project.description}</p>
-              {project.links?.demo && (
+              {project.links?.demo && project.links.demo.trim() !== "" && (
                 <p className={styles.projectLinks}>
-                  <strong className={styles.projectLinkText}>Link:</strong>{" "}
-                  <a href={project.links.demo} target="_blank" rel="noopener noreferrer" className={styles.projectLink}>
-                    {project.links.demo}
-                  </a>
+                  <strong className={styles.projectLinkText}>• Demo: </strong>
+                  <span className={styles.projectLinkUrl}> {project.links.demo}</span>
+                </p>
+              )}
+              {project.links?.repo && project.links.repo.trim() !== "" && (
+                <p className={styles.projectLinks}>
+                  <strong className={styles.projectLinkText}>• Código: </strong>
+                  <span className={styles.projectLinkUrl}> {project.links.repo}</span>
                 </p>
               )}
             </div>

--- a/src/pages/print-page.module.css
+++ b/src/pages/print-page.module.css
@@ -135,6 +135,11 @@
   color: #4a5568;
 }
 
+.projectContainer {
+  border-bottom: 1px solid #e2e8f0;
+  padding: 16px;
+}
+
 .projectTitle {
   font-size: 18px;
   font-weight: 600;
@@ -164,7 +169,15 @@
 
 .projectLinkText {
   font-size: 14px;
-  padding-bottom: 16px;
+  padding: 4px;
+}
+
+.projectLinkUrl {
+  font-size: 14px;
+  color: #3182ce;
+  text-decoration: underline;
+  padding: 4px;
+  cursor: pointer;
 }
 
 .languageItem {


### PR DESCRIPTION
Este pull request atualiza a lógica dos links do projeto e melhora a experiência do usuário nas seções de contato e projetos. As principais alterações envolvem a troca do campo de link do repositório do projeto de `github` para `repo`, a atualização da forma como os links do projeto são exibidos e manipulados nas visualizações web e de impressão, e o aprimoramento do formulário de contato para redirecionar os usuários ao WhatsApp.

**Atualização e melhorias na exibição do campo de links do projeto:**

* O tipo `Project` em `PrintPage.tsx` foi alterado para usar `repo` em vez de `github` para links de repositório, garantindo uma nomenclatura consistente em toda a base de código.
* As visualizações web (`ProjectsSection.tsx`) e de impressão (`PrintPage.tsx`) foram atualizadas para renderizar condicionalmente links de demonstração e repositório apenas quando presentes e não vazios, e todas as referências foram trocadas de `github` para `repo`.

**Aprimoramento no formulário de contato:**

* Modificada a lógica de envio do formulário de contato em `ContactSection.tsx` para redirecionar os usuários ao WhatsApp com uma mensagem pré-preenchida, em vez de simular o envio de um formulário, melhorando o engajamento do usuário e agilizando a comunicação.

**Melhorias de estilo para a visualização de impressão:**

* Adicionado o estilo `.projectContainer` para melhor separação de projetos na visualização de impressão e aprimorado o estilo de links com `.projectLinkUrl` para maior clareza e usabilidade.